### PR TITLE
AddMetrics cannot accept IHealthRoot as a parameter

### DIFF
--- a/content/web-monitoring/aspnet-core/health.md
+++ b/content/web-monitoring/aspnet-core/health.md
@@ -132,7 +132,7 @@ public class Startup
             ... // configure options and add health checks
             .Build();
 
-        services.AddMetrics(metrics);
+        services.AddHealth(metrics);
         services.AddHealthEndpoints();
     }
 }


### PR DESCRIPTION
`IServiceCollection.AddHealth should` be used.