### PR TITLE
fix(nav): stay in page if shift/ctrl pressed

### DIFF
--- a/themes/hugo-theme-learn/static/js/learn.js
+++ b/themes/hugo-theme-learn/static/js/learn.js
@@ -225,12 +225,12 @@ jQuery(document).ready(function() {
 
     jQuery(document).keydown(function(e) {
       // prev links - left arrow key
-      if(e.which == '37') {
+      if(e.which == '37' && !e.shiftKey && !e.ctrlKey) {
         jQuery('.nav.nav-prev').click();
       }
 
       // next links - right arrow key
-      if(e.which == '39') {
+      if(e.which == '39'  && !e.shiftKey && !e.ctrlKey) {
         jQuery('.nav.nav-next').click();
       }
     });


### PR DESCRIPTION
Today we were talking about this in the afternoon, I always read by highlighting, (double click at first, then read while highlighting with Ctrl + shift + arrow), this way my eye knows exactly where to read from.

Turns out small number of people do this, out of all my friends about 50% of them did this (considering my friends were other fellow programmers), in real sample space it'd be much less, but again AppMetrics' target isn't those people.

I always get annoyed when I try to do that and it decides to go to next page, while I do appreciate the keyboard shortcuts I just don't want them in my way when I'm trying to get a good read.

I always end up disabling JavaScript when I'm in this docs.

This PR aims to detect shift and ctrl keys, and if those are pressed, it simply doesn't navigate away.

I hope you merge this and it goes live very soon.