### PR TITLE
Updated formatter configuration sample code

### DIFF
--- a/content/reporting/reporters/prometheus.md
+++ b/content/reporting/reporters/prometheus.md
@@ -72,8 +72,8 @@ public static class Program
                             {
                                 options.EndpointOptions = endpointsOptions =>
                                 {
-                                    endpointsOptions.MetricsTextEndpointOutputFormatter = Metrics.OutputMetricsFormatters.GetType<MetricsPrometheusTextOutputFormatter>();
-                                    endpointsOptions.MetricsEndpointOutputFormatter = Metrics.OutputMetricsFormatters.GetType<MetricsPrometheusProtobufOutputFormatter>();
+                                    endpointsOptions.MetricsTextEndpointOutputFormatter = Metrics.OutputMetricsFormatters.OfType<MetricsPrometheusTextOutputFormatter>().First();
+                                    endpointsOptions.MetricsEndpointOutputFormatter = Metrics.OutputMetricsFormatters.OfType<MetricsPrometheusProtobufOutputFormatter>().First();
                                 };
                             })
                         .UseStartup<Startup>()


### PR DESCRIPTION
The current sample code won't compile due to '_CS0308: The non-generic method 'object.GetType()' cannot be used with type arguments_'.

Alternatively, one could do:

```csharp
endpointsOptions.MetricsTextEndpointOutputFormatter = new MetricsPrometheusTextOutputFormatter();
endpointsOptions.MetricsEndpointOutputFormatter = new MetricsPrometheusProtobufOutputFormatter();
```

I am not sure of the benefits of re-using the IMetricsRoot object for getting formatter instances.