### PR TITLE
Endpointconfguration needs starting slash

### DIFF
--- a/content/web-monitoring/aspnet-core/health.md
+++ b/content/web-monitoring/aspnet-core/health.md
@@ -215,7 +215,7 @@ var webHostBuilder = WebHost.CreateDefaultBuilder(args)
     .ConfigureAppHealthHostingConfiguration(options =>
     {
         options.AllEndpointsPort = 1111;
-        options.HealthEndpoint = "app-metrics-health";
+        options.HealthEndpoint = "/app-metrics-health";
     });
     
 ...


### PR DESCRIPTION
This is a small change but registering an endpoint needs to start with slash '/'
I have checked it.