### PR TITLE
Parameter change for GrafanaCloud Hosted Metrics

### DIFF
--- a/content/reporting/reporters/grafanacloud-hostedmetrics.md
+++ b/content/reporting/reporters/grafanacloud-hostedmetrics.md
@@ -9,6 +9,16 @@ icon: "/images/grafana.png"
 
 The [App.Metrics.Reporting.GrafanaCloudHostedMetrics](https://www.nuget.org/packages/App.Metrics.Reporting.GrafanaCloudHostedMetrics/) nuget package reports metrics to [GrafanaCloud Hosted Metrics](https://grafana.com/cloud/metrics) using the [App.Metrics.Formatters.GrafanaCloudHostedMetrics](https://www.nuget.org/packages/App.Metrics.Formatters.GrafanaCloudHostedMetrics/) nuget package to format metrics.
 
+### GrafanCloud URL, API Key and UserId
+
+You will need these three to correctly configure App.Metrics to report to GrafanaCloud Hosted Metrics.
+
+By default a graphite hosted metrics instance is created for you when you sign up to GrafanaCloud Hosted Metrics, usually named *[YourOrganisation]-graphite*. You can see this at https://grafana.com/orgs/[YourOrganisation]/hosted-metrics
+
+Within that hosted metrics instance you will see a section titled 'Using Grafana with Hosted Metrics'. The data source by default will be of type graphite, usually named *grafanacloud-[YourOrganisation]-graphite*. You can find your User id in here along with the URL. Ensure that 'Basic Auth' is checked.
+
+You can view the metrics being published within the grafana cloud instance at https://*[YourOrganisation]*.grafana.net/. Note: You must create a dashboard and configure queries to filter on your new metrics.
+
 ### Getting started
 
 <i class="fa fa-hand-o-right"></i> To use the GrafanaCloud Hosted Metrics reporter, first install the [nuget package](https://www.nuget.org/packages/App.Metrics.Reporting.GrafanaCloudHostedMetrics/):
@@ -21,7 +31,7 @@ nuget install App.Metrics.Reporting.GrafanaCloudHostedMetrics
 
 ```csharp
 var metrics = new MetricsBuilder()
-    .Report.ToHostedMetrics("base url of your hosted metrics", "your hosted metrics api key")
+    .Report.ToHostedMetrics("base url of your hosted metrics", "userid of host metrics data source:your grafana.com hosted metrics api key")
     .Build();
 ```
 
@@ -47,7 +57,7 @@ var metrics = new MetricsBuilder()
     .Report.ToHostedMetrics(
         options => {
             options.HostedMetrics.BaseUri = "base url of your hosted metrics";
-            options.HostedMetrics.ApiKey = "your hosted metrics api key";
+            options.HostedMetrics.ApiKey = "userid of host metrics data source:your grafana.com hosted metrics api key";
             options.HttpPolicy.BackoffPeriod = TimeSpan.FromSeconds(30);
             options.HttpPolicy.FailuresBeforeBackoff = 5;
             options.HttpPolicy.Timeout = TimeSpan.FromSeconds(10);
@@ -63,9 +73,9 @@ var metrics = new MetricsBuilder()
 |------|:--------|
 |MetricsHostedMetricsJsonOutputFormatter|The metric payment formatter used when reporting metrics to GrafanCloud Hosted Metrics.
 |Filter|The filter used to filter metrics just for this reporter.
-|FlushInterval|The delay between reporting metrics to InfluxDB.
-|InfluxDb.BaseUri|The URI of the GrafanaCloud Hosted Metrics instance.
-|InfluxDb.ApiKey|The Api Key which your application will use to authenticate with GrafanaCloud Hosted Metrics.
+|FlushInterval|The delay between reporting metrics.
+|BaseUri|The URI of the GrafanaCloud Hosted Metrics instance.
+|ApiKey|The Api Key which your application will use to authenticate with GrafanaCloud Hosted Metrics. Prefix this with the user id of the hosted metrics data source (by default the graphite instance) and a colon. eg: 1234:apikey
 |HttpPolicy.BackoffPeriod|The `TimeSpan` to back-off when metrics are failing to report to the metrics ingress endpoint.
 |HttpPolicy.FailuresBeforeBackoff|The number of failures before backing-off when metrics are failing to report to the metrics ingress endpoint.
 |HttpPolicy.Timeout|The HTTP timeout duration when attempting to report metrics to the metrics ingress endpoint.


### PR DESCRIPTION
Updating to indicate that the user cannot simply take their grafana.com api key, but must also prefix it with the user id of the hosted metrics data source.

Adding some clarity around this to assist users in "getting started" with Grafana Cloud.

Following issue: https://github.com/AppMetrics/AppMetrics/issues/454