### PR TITLE
Fixed formatting on appInsights page

### DIFF
--- a/content/reporting/reporters/app-insights.md
+++ b/content/reporting/reporters/app-insights.md
@@ -9,6 +9,7 @@ icon: "/images/cmd.png"
 1. Install nuget package: [App.Metrics.Reporting.ApplicationInsights](https://www.nuget.org/packages/App.Metrics.Reporting.ApplicationInsights/)
 2. Obtain Application Insights [instrumentation key](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource).
 3. Configure App.Metrics like so:
+
 ```
 using App.Metrics.Reporting.ApplicationInsights;
 


### PR DESCRIPTION
Looks https://www.app-metrics.io/reporting/reporters/app-insights/ page has corrupted formatting. And my guess would be in missing new line. This is a try to fix formatting for code example on that page