### PR TITLE
Use auto-property instead of expression-bodied syntax

### DIFF
--- a/content/getting-started/fundamentals/recording-metrics.md
+++ b/content/getting-started/fundamentals/recording-metrics.md
@@ -16,31 +16,31 @@ Each metric being measured is defined via one the available [metric types]({{< r
 ```csharp
 public static class MyMetricsRegistry
 {
-    public static GaugeOptions Errors => new GaugeOptions
+    public static GaugeOptions Errors { get; } = new GaugeOptions
     {
         Name = "Errors"
     };
 
-    public static CounterOptions SampleCounter => new CounterOptions
+    public static CounterOptions SampleCounter { get; } = new CounterOptions
     {
         Name = "Sample Counter",
         MeasurementUnit = Unit.Calls,
     };
 
-    public static HistogramOptions SampleHistogram => new HistogramOptions
+    public static HistogramOptions SampleHistogram { get; } = new HistogramOptions
     {
         Name = "Sample Histogram",
         Reservoir = () => new DefaultAlgorithmRReservoir(),
         MeasurementUnit = Unit.MegaBytes
     };
 
-    public static MeterOptions SampleMeter => new MeterOptions
+    public static MeterOptions SampleMeter { get; } = new MeterOptions
     {
         Name = "Sample Meter",
         MeasurementUnit = Unit.Calls
     };
 
-    public static TimerOptions SampleTimer => new TimerOptions
+    public static TimerOptions SampleTimer { get; } = new TimerOptions
     {
         Name = "Sample Timer",
         MeasurementUnit = Unit.Items,
@@ -49,7 +49,7 @@ public static class MyMetricsRegistry
         Reservoir = () => new DefaultForwardDecayingReservoir(sampleSize: 1028, alpha: 0.015)
     };
 
-    public static ApdexOptions SampleApdex => new ApdexOptions
+    public static ApdexOptions SampleApdex { get; } = new ApdexOptions
     {
         Name = "Sample Apdex"
     };


### PR DESCRIPTION
Hey there,

In the MyMetricsRegistry class, there are two properties named Errors and Errors2 that define instances of the GaugeOptions class. While both properties serve the same purpose, they have slightly different behavior, which may not be immediately clear to developers who are new to the codebase.

Errors property returns a single instance of GaugeOptions, whereas Errors2 creates a new instance of GaugeOptions every time it is accessed.

```csharp
public static class MyMetricsRegistry
{
    public static GaugeOptions Errors { get; } = new GaugeOptions
    {
        Name = "Errors"
    };

    public static GaugeOptions Errors2 => new GaugeOptions
    {
        Name = "Errors2"
    };
}
```